### PR TITLE
Feature/fix schedule dialog

### DIFF
--- a/src/components/schedule-dialog.vue
+++ b/src/components/schedule-dialog.vue
@@ -49,7 +49,6 @@
               :items="items"
               label="Select a member"
               prepend-icon="account_circle"
-              item-value="account"
               max-height="20rem"
               return-object
               autocomplete
@@ -199,7 +198,7 @@ export default {
   },
   methods: {
     setData (data) {
-      data.forEach(d => { d.text = d.name + ' ' + d.account })
+      data.forEach(d => { d.text = d.name + (d.account ? ' ' + d.account : '') })
       this.items = data
       this.selectedItems = data.filter(d => d[this.idField]).sort(
         (r, l) => {


### PR DESCRIPTION
If some people have no account (account in contact list is null), schedule dialog drawdown list not showing them.
Fix by remove item key (account) in v-select in order to make v-select not filter out these people.

Well but I'm not sure what is the purpose of `item-value:"account"` XD, hope I'm not making bugs.
